### PR TITLE
Change comma notations to double comma to avoid conflict with Ltac

### DIFF
--- a/examples/Lambda.v
+++ b/examples/Lambda.v
@@ -122,7 +122,7 @@ Qed.
 Lemma ctx_extend_substitution {Γ Δ x} {A : type} {r} :
   forall_has Γ (fun v B => Δ ⊢ [r] (vv v) ~ B) ->
   forall_has (Γ & x ~ A)
-    (fun v B => Δ & x ~ A ⊢ [r,x] (vv v) ~ B).
+    (fun v B => Δ & x ~ A ⊢ [r,,x] (vv v) ~ B).
 Proof.
   intros H.
   apply forall_has_cons; names.

--- a/src/Context.v
+++ b/src/Context.v
@@ -101,11 +101,11 @@ Notation "Γ =[ r ]=> Δ" :=
 Lemma ctx_shift {trm A : Set} :
   forall Γ Δ x (a : A) (r : @renaming trm),
     Γ =[r]=> Δ ->
-    Γ =[r, ^x]=> (Δ & x ~ a).
+    Γ =[r,, ^x]=> (Δ & x ~ a).
 Proof.
   intros * H.
   destruct H as [? ? r rn H].
-  apply relates_intro with (s := (r, ^x)%ren) (total := rn).
+  apply relates_intro with (s := (r,, ^x)%ren) (total := rn).
   apply (forall_has_map H); intros y b. 
   cbn; autorewrite with rw_vars rw_names.
   auto.
@@ -114,12 +114,12 @@ Qed.
 Lemma ctx_rename {trm A : Set} :
   forall Γ Δ x y (a : A) (r : @renaming trm),
     Γ =[r]=> Δ ->
-    (Γ & x ~ a) =[r, y <- x]=> (Δ & y ~ a).
+    (Γ & x ~ a) =[r,, y <- x]=> (Δ & y ~ a).
 Proof.
   intros * H.
   destruct H as [? ? r rn H].
   apply relates_intro
-    with (s := (r, y <- x)%ren) (total := rn); cbn.
+    with (s := (r,, y <- x)%ren) (total := rn); cbn.
   apply forall_has_cons;
     autorewrite with rw_vars rw_names; cbn; auto.
   apply (forall_has_map H); intros z c. 

--- a/src/Relative.v
+++ b/src/Relative.v
@@ -389,12 +389,12 @@ Module Renamings (T : Term).
 
   (* FIXME: maybe this should just be "names"? *)
   Lemma rw_close_shift a r {V} (t : @term V) :
-    close a ([r, ^a] t) = wk ([r] t).
+    close a ([r,, ^a] t) = wk ([r] t).
   Proof.
     simpl_term_eq; autorewrite with rw_renaming; simpl_term_eq.
   Qed.
   Lemma rw_subst_open u r b {V} (t : @term (S V)) :
-    [r, u // b] (open b t) = bind u ([r] t).
+    [r,, u // b] (open b t) = bind u ([r] t).
   Proof. simpl_term_eq. Qed.
   Lemma rw_rename_open a b {V} (t : @term (S V)) :
     [a <- b] (open b t) = open a t.
@@ -418,7 +418,7 @@ Module Renamings (T : Term).
   (* Shifts go the other way.
      This is confluent/terminating because shift doesn't simplify to apply (?) *)
   Lemma rw_push_bind_shift u r s a {V} (t : @term (S V)) :
-    bind ([r, ^a] u) ([s, ^ a] t) =
+    bind ([r,, ^a] u) ([s,, ^ a] t) =
     [^a] (bind ([r]u) ([s]t)).
   Proof.
     rewrite comm_bind_apply.
@@ -615,10 +615,10 @@ Module Renamings (T : Term).
   (* Commuting open and close with apply *)
   
   Lemma rw_push_open a r {V} (t : @term (S V)) :
-    open a ([r] t) = [r, a] (open a t).
+    open a ([r] t) = [r,, a] (open a t).
   Proof. simpl_term_eq. Qed.
   Lemma rw_push_close a r {V} (t : @term V) :
-    [r] (close a t) = close a ([r, a] t).
+    [r] (close a t) = close a ([r,, a] t).
   Proof.  simpl_term_eq. Qed.
   Hint Rewrite @rw_push_open @rw_push_close : rw_renaming.
 

--- a/src/Var.v
+++ b/src/Var.v
@@ -880,13 +880,14 @@ Inductive renaming {trm : Set} :=
 | r_rename (b : name) (r : renaming) (a : name)
 | r_subst (t : trm) (r : renaming) (a : name).
 
+Declare Scope ren_scope.
 Notation "r1 ; r2" := (r_comp r1 r2)
   (at level 57, right associativity) : ren_scope.
-Notation "r , ^ a" := (r_shift a r)
+Notation "r ,, ^ a" := (r_shift a r)
   (at level 47, left associativity) : ren_scope.
-Notation "r , a <- b" := (r_rename a r b)
+Notation "r ,, a <- b" := (r_rename a r b)
   (at level 47, left associativity, a at next level) : ren_scope.
-Notation "r , u // a" := (r_subst u r a)
+Notation "r ,, u // a" := (r_subst u r a)
   (at level 47, left associativity, u at next level) : ren_scope.
 Notation "^ a" := (r_shift a r_id)
   (at level 47, left associativity) : ren_scope.
@@ -894,7 +895,7 @@ Notation "a <- b" := (r_rename a r_id b)
   (at level 47, left associativity) : ren_scope.
 Notation "u // a" := (r_subst u r_id a)
   (at level 47, left associativity) : ren_scope.
-Notation "r , a" := (r_rename a r a)
+Notation "r ,, a" := (r_rename a r a)
   (at level 47, left associativity) : ren_scope.
 
 Delimit Scope ren_scope with ren.


### PR DESCRIPTION
Resolves #1 . Went with ",," because it seemed easiest.